### PR TITLE
Remove erroneous and ineffective mapping for gradle.build

### DIFF
--- a/exercises/testing_layers/docker-compose.yml
+++ b/exercises/testing_layers/docker-compose.yml
@@ -5,7 +5,6 @@ services:
       - "3001:3001"
     volumes:
       - "./src:/app/src"
-      - "./gradle.build:/app/gradle.build"
       - "~/.m2:/root/.m2"
     working_dir: /app
     command: ["watchexec", "--watch", "src", "--exts", "java", "--restart", "gradle run"]
@@ -14,7 +13,6 @@ services:
     build: .
     volumes:
       - "./src:/app/src"
-      - "./gradle.build:/app/gradle.build"
       - "~/.m2:/root/.m2"
     working_dir: /app
     command: gradle test --continuous


### PR DESCRIPTION
This was used in another exercise, but I incorrectly copied it as `gradle.build` rather than `build.gradle`. However it is unnecessary in any case as the `Dockerfile` copies `build.gradle` in anyway.